### PR TITLE
fix: Update Gemini review prompt to be more specific

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,9 @@ jobs:
       - name: Debug GEMINI_API_KEY
         run: echo "Key length is ${#GEMINI_API_KEY}"   # should print a nonzero number
       - name: Install gemini-cli
-        run: npm install -g @google/gemini-cli
+        run: |
+          npm cache clean --force
+          npm install -g @google/gemini-cli
       - name: Generate Gemini Review
         id: gemini_review_step
         run: |


### PR DESCRIPTION
This PR updates the prompt in the Gemini review workflow to be more specific and only use the PR diff for context. This should fix issue #19.\n\nCloses #19